### PR TITLE
bored waiting on phonecalls => elisp

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -263,3 +263,17 @@ task 'mirah/fullpath' => 'mirah/fullpath.mirah' do
              '--dest', 'mirah',
              'mirah/fullpath.mirah'
 end
+
+# =====  ELISP  =====
+desc 'Build / Test fullpath for Emacs Lisp'
+task(emacs: 'emacs/fullpath') { cucumber 'emacs' }
+file 'emacs/fullpath' => 'emacs/fullpath.el' do
+  File.open(File.expand_path('./emacs/fullpath', __dir__), 'w') do |f|
+    f.write <<EOF
+#!/usr/bin/env bash
+base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+emacs --script "$base_dir"/fullpath.el -- "$@"
+EOF
+  end
+  chmod '+x', 'emacs/fullpath'
+end

--- a/emacs/fullpath
+++ b/emacs/fullpath
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+emacs --script "$base_dir"/fullpath.el -- "$@"

--- a/emacs/fullpath.el
+++ b/emacs/fullpath.el
@@ -1,0 +1,57 @@
+(require 'cl)
+(require 'subr-x)
+
+(defun expand (path &optional relative-to-dir)
+  (directory-file-name (expand-file-name path relative-to-dir)))
+
+(defun show-help ()
+  (princ "usage: fullpath *[relative-paths] [-c]
+
+  Prints the fullpath of the paths
+  If no paths are given as args, it will read them from stdin
+
+  If there is only one path, the trailing newline is omitted
+
+  The -c flag will copy the results into your pasteboard
+"))
+
+(defun pbcopy (s)
+  (with-temp-buffer
+    (insert s)
+    (call-process-region (point-min) (point-max) "pbcopy")))
+
+(defun emit (paths copy-to-pasteboard)
+  (let* ((unterminated (string-join paths "\n"))
+         (out (if (> (length paths) 1)
+                  (concat unterminated "\n")
+                unterminated)))
+    (princ out)
+    (when copy-to-pasteboard (pbcopy out))))
+
+(defun help? (args)
+  (cl-find-if (lambda (v) (or (string-equal "-h" v)
+                              (string-equal "--help" v)))
+              args))
+
+(defun consume-stdin ()
+  (let (lines)
+    (condition-case nil
+        (while (setq line (read-from-minibuffer ""))
+          (setq lines (cons line lines)))
+      (error nil))
+    (reverse lines)))
+
+(defun main (args copy-to-pasteboard)
+  (let ((paths (cl-remove-if 'string-blank-p args)))
+    (emit (mapcar 'expand paths) copy-to-pasteboard)))
+
+(let* ((argv (if (string-equal "--" (car command-line-args-left))
+                 (cdr command-line-args-left)
+               command-line-args-left))
+       (copy-to-pasteboard (let ((final-arg (car (last argv))))
+                             (or (string-equal final-arg "-c")
+                                 (string-equal final-arg "--copy"))))
+       (argv (if copy-to-pasteboard (butlast argv 1) argv)))
+  (if (help? argv)
+      (show-help)
+    (main (or argv (consume-stdin)) copy-to-pasteboard)))


### PR DESCRIPTION
emacs implementation

I used `string-blank-p` from subr-x, which requires Emacs >= 24.4. It's
a one-liner to replace if you really wanted to support earlier versions:

```
(defsubst string-blank-p (string)
  "Check whether STRING is either empty or only whitespace."
  (string-match-p "\\`[ \t\n\r]*\\'" string))
```

```
~/sauce/language-sampler-for-fullpath (emacs) » rake emacs | tail -3
bundle exec cucumber -t ~@not-implemented
11 scenarios (11 passed)
53 steps (53 passed)
0m1.901s
```
